### PR TITLE
feat(capabilities): add Slalom Build capability (Fixes #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -104,6 +104,21 @@ capabilities = {
     }
 }
 
+# Add Slalom Build capability (urgent client demand)
+capabilities["Slalom Build"] = {
+    "description": "End-to-end product development: strategy, UX, and agile delivery",
+    "practice_area": "Technology",
+    "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+    "certifications": [
+        "Certified Product Manager",
+        "Scrum Product Owner",
+        "Agile Practitioner"
+    ],
+    "industry_verticals": ["Consumer Products", "Fintech", "Healthtech"],
+    "capacity": 30,
+    "consultants": []
+}
+
 
 @app.get("/")
 def root():


### PR DESCRIPTION
Adds the Slalom Build capability to the in-memory capabilities in src/app.py, enabling consultant registration and staffing for product development engagements.

Changes:
- New capability: “Slalom Build” with description, practice area, skill levels, certifications (Product Management, Agile), industry verticals (Consumer Products, Fintech, Healthtech), capacity, and an empty consultant list.
- No API shape changes; frontend auto-populates from `/capabilities`, so the new capability appears in the list and the registration dropdown.

Rationale:
Addresses urgent, time-sensitive demand noted in issue #6 (client proposals due next week). Adding the capability immediately enables consultant registration and supports upcoming engagements while broader governance and UX changes are planned separately.

Testing:
- Run: `/workspaces/moooochi/.venv/bin/python -m uvicorn src.app:app --host 0.0.0.0 --port 8000`
- Verify API: `curl -s http://localhost:8000/capabilities | grep "Slalom Build"`
- Verify UI: open http://localhost:8000/ and confirm “Slalom Build” appears in capability cards and the registration dropdown.

Linked Issue: Fixes #6